### PR TITLE
Add Codex prompt template for chapter exports

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,116 @@ Generally, you only want to look at the main umineko script, on the master branc
 
 The main umineko script file for development is located in `InDevelopment\ManualUpdates\0.utf`
 
+## Generating EPUB chapter exports
+
+The repository now includes a lightweight extraction script that turns the
+massive `0.utf` scenario file into chapter-sized JSON dumps that are ready for
+your EPUB tooling.  The example below walks through exporting the Episode 1
+opening and producing a very simple EPUB that you can open on an e-reader.
+
+1. **Prepare Python.** Any recent Python 3 (3.9+) works.  Optionally create a
+   virtual environment to keep things tidy:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+
+2. **Run the chapter extractor.** The helper reads the configuration in
+   `tools/chapter_plan.json` and slices `0.utf` between the configured labels.
+   This repository ships with the Episode 1 opening configured out of the box:
+
+   ```bash
+   python tools/extract_chapter.py \
+     --config tools/chapter_plan.json \
+     --chapter episode1-opening \
+     --output-dir build/epub
+   ```
+
+   The command above creates `build/epub/episode1-opening.json`.  Tweak the
+   `--chapter` argument (or extend `chapter_plan.json`) when you are ready to
+   export more sections of the script.  The JSON bundle contains the prose,
+   dialogue metadata, and the speaker roster required for EPUB assembly.
+
+### Prompt template for automated chapter exports
+
+When you queue additional Codex jobs to generate JSON dumps, you can reuse the
+prompt below.  Replace the placeholders with the Episode and Chapter you would
+like to export; the helper will extend `tools/chapter_plan.json` if necessary
+and then run the extractor to write the chapter bundle under `build/epub/`.
+
+```
+You are working in the 07th-Mod/umineko-question repository.  Generate a chapter
+JSON export for the visual novel "Umineko no Naku Koro ni" using the existing
+`tools/extract_chapter.py` helper.  The Episode is: <EPISODE NAME/NUMBER>.  The
+Chapter is: <CHAPTER TITLE>.  Ensure the chapter is defined in
+`tools/chapter_plan.json` (add or adjust the entry if missing) and then run:
+
+python tools/extract_chapter.py \
+  --config tools/chapter_plan.json \
+  --chapter <SLUG-FOR-EPISODE-AND-CHAPTER> \
+  --output-dir build/epub
+
+Report the path of the resulting JSON file when you are finished.
+```
+
+3. **(Optional) Convert the JSON to Markdown.** While the extractor stops at a
+   JSON document, the snippet below generates a quick Markdown rendering that
+   tools such as `pandoc` understand.  Feel free to adapt it to your preferred
+   pipeline:
+
+   ```bash
+   python - <<'PY'
+   import json
+   from pathlib import Path
+
+   payload = json.loads(Path('build/epub/episode1-opening.json').read_text(encoding='utf-8'))
+   md_path = Path('build/epub/episode1-opening.md')
+
+   with md_path.open('w', encoding='utf-8') as handle:
+       chapter = payload['chapter']
+       handle.write(f"# {chapter['title']}\n\n")
+       handle.write(f"_From {chapter['episode']}_\n\n")
+
+       for entry in payload['entries']:
+           entry_type = entry['type']
+
+           if entry_type == 'narration':
+               text = entry.get('text', '').strip()
+               if text:
+                   handle.write(text + "\n\n")
+           elif entry_type == 'dialogue':
+               speaker = entry.get('speaker') or payload['speakers'].get(entry.get('speaker_id', ''), {}).get('name', 'Unknown speaker')
+               text = entry.get('text', '').strip()
+               if text:
+                   handle.write(f"**{speaker}:** {text}\n\n")
+           elif entry_type == 'music':
+               raw = entry.get('raw') or entry.get('command')
+               if raw:
+                   handle.write(f"*Music cue: {raw}*\n\n")
+
+   print(f"Wrote {md_path}")
+   PY
+   ```
+
+4. **Produce the EPUB container.** Any EPUB authoring stack works here.  As one
+   concrete option, `pandoc` can turn the Markdown into a fully valid EPUB file
+   (install it from https://pandoc.org/installing.html if you do not have it):
+
+   ```bash
+   pandoc build/epub/episode1-opening.md \
+     --metadata title="Episode 1 – Opening" \
+     --metadata author="07th-Mod team" \
+     -o build/epub/episode1-opening.epub
+   ```
+
+   You can now sideload `build/epub/episode1-opening.epub` onto an e-reader or
+   open it with any desktop EPUB viewer.  Update the metadata or apply your own
+   styling as you iterate on the layout.
+
+See [`tools/EPUB_WORKFLOW.md`](tools/EPUB_WORKFLOW.md) for more context about
+maintaining the chapter plan and extending the export list.
+
 ## Folder structure:
 
 - `InDevelopment\ManualUpdates\0.utf`: The main umineko script file, where development happens


### PR DESCRIPTION
## Summary
- document a reusable Codex prompt for requesting additional chapter JSON exports

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d07c55dba483338b4cd28ec101016e